### PR TITLE
Agregar script para renombrar archivos de canciones basado en metadatos de YouTube

### DIFF
--- a/db_downloaded_songs/after 2018/La Ludwig Band - A les portes del paradís (àudio oficial).mp3
+++ b/db_downloaded_songs/after 2018/La Ludwig Band - A les portes del paradís (àudio oficial).mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa49dcace371b67073ceea10793eeee449dbf5b9783b1ec6b469f3444cf26be6
+size 4982445

--- a/db_downloaded_songs/after 2018/La Ludwig Band - Per allà Lesseps (àudio oficial).mp3
+++ b/db_downloaded_songs/after 2018/La Ludwig Band - Per allà Lesseps (àudio oficial).mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9041b3d0c158ee2c254023823e13d91808dc0abe025153b852106386344a6419
+size 4062573

--- a/db_downloaded_songs/before 2012/La cançó del soldadet.mp3
+++ b/db_downloaded_songs/before 2012/La cançó del soldadet.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e25442a19cd37066d5b747e2e9fe46b9fecf42182c0cbe264a0bf9e3ff8b32b0
+size 5707629

--- a/db_downloaded_songs/before 2012/Manel - Els guapos són els raros (Audio Oficial).mp3
+++ b/db_downloaded_songs/before 2012/Manel - Els guapos són els raros (Audio Oficial).mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de5f657927bc429d90361634764aaf756d1ee543262cd839718e4d8dc51d67eb
+size 5207085

--- a/youtube_playlist_scraper/song_renamer.py
+++ b/youtube_playlist_scraper/song_renamer.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import os
+import csv
+import argparse
+import sys
+
+def sanitize(text: str) -> str:
+    """
+    Convert text to lowercase, remove " - topic" and " oficial", strip whitespace.
+    """
+    text = text.lower()
+    # remove unwanted substrings
+    text = text.replace(' - topic', '')
+    text = text.replace(' oficial', '')
+    return text.strip()
+
+def load_metadata(csv_path: str) -> dict:
+    """
+    Read the CSV and return a mapping from video_id to (channel_name, song_title).
+    """
+    mapping = {}
+    try:
+        with open(csv_path, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                vid = row.get('video_id', '').strip()
+                channel = row.get('channel_name', '').strip()
+                title = row.get('song_title', '').strip()
+                if not vid or not channel or not title:
+                    # skip incomplete rows
+                    continue
+                mapping[vid] = (channel, title)
+    except Exception as e:
+        print(f"Error reading metadata file: {e}", file=sys.stderr)
+        sys.exit(1)
+    return mapping
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Rename song files based on YouTube metadata"
+    )
+    parser.add_argument(
+        "directory",
+        help="Path to the folder containing song files to rename"
+    )
+    args = parser.parse_args()
+    target_dir = args.directory
+
+    if not os.path.isdir(target_dir):
+        print(f"Error: '{target_dir}' is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    # locate CSV next to this script
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    csv_path = os.path.join(script_dir, "catalan_music_metadata.csv")
+    if not os.path.isfile(csv_path):
+        print(f"Error: metadata file not found at '{csv_path}'.", file=sys.stderr)
+        sys.exit(1)
+
+    metadata = load_metadata(csv_path)
+
+    # iterate files in target directory
+    for filename in os.listdir(target_dir):
+        orig_path = os.path.join(target_dir, filename)
+        if not os.path.isfile(orig_path):
+            continue
+
+        renamed = False
+        for vid, (channel, title) in metadata.items():
+            if vid in filename:
+                ext = os.path.splitext(filename)[1]
+                new_base = f"{sanitize(channel)}-{sanitize(title)}"
+                new_name = new_base + ext
+                new_path = os.path.join(target_dir, new_name)
+
+                if filename == new_name:
+                    print(f"Skipping '{filename}': already correctly named.")
+                elif os.path.exists(new_path):
+                    print(f"Warning: target name '{new_name}' already exists; skipping '{filename}'.")
+                else:
+                    os.rename(orig_path, new_path)
+                    print(f"Renamed '{filename}' → '{new_name}'")
+                renamed = True
+                break
+
+        if not renamed:
+            # no matching video_id
+            continue
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces two main changes: the addition of metadata for audio files using Git LFS and the implementation of a Python script to rename song files based on YouTube metadata. Below is a summary of the most important changes:

### Metadata for audio files
* Added Git LFS metadata for four audio files: `La Ludwig Band - A les portes del paradís`, `La Ludwig Band - Per allà Lesseps`, `La cançó del soldadet`, and `Manel - Els guapos són els raros`. Each file now includes a version, an object ID, and a size attribute. [[1]](diffhunk://#diff-bbb5a1b1c6baa06fb4b4a6587339c56249e722c7d206a01eaff06dd7f19b1861R1-R3) [[2]](diffhunk://#diff-c2991ed9a2adca662472d1e57af7053b28471fe4fe17e257144018c30a262ab2R1-R3) [[3]](diffhunk://#diff-fc5ae53a565e2bd2716e73eefea0ddeadbbf3422516467036051f9a30ea0c075R1-R3) [[4]](diffhunk://#diff-56bd84258fb8ad7d52cd46b26b5915e1767f7cd32e801fc37f12c810c3b0e7efR1-R3)

### Song renaming script
* Introduced a new Python script, `song_renamer.py`, to rename song files in a specified directory based on metadata from a CSV file. Key features include:
  - Sanitizing text by removing unwanted substrings and converting to lowercase.
  - Loading metadata from a CSV file (`catalan_music_metadata.csv`) into a dictionary mapping video IDs to channel names and song titles.
  - Iterating through files in the target directory, matching video IDs in filenames to metadata, and renaming files accordingly while handling conflicts (e.g., existing target names).