### PR TITLE
Maest embeddings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.wav filter=lfs diff=lfs merge=lfs -text
 *.mp3 filter=lfs diff=lfs merge=lfs -text
 *.pkl filter=lfs diff=lfs merge=lfs -text
+*.pb filter=lfs diff=lfs merge=lfs -text

--- a/code/essentia-models/maest/discogs-maest-30s-pw-1.pb
+++ b/code/essentia-models/maest/discogs-maest-30s-pw-1.pb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4140c0ce46c993da48fc1cc58d0cb317631f1043bc2ee735cc573fa66a25b4d5
+size 350023292

--- a/code/essentia-models/maest/embeddings/after_2018-2025-05-08_maest.pkl
+++ b/code/essentia-models/maest/embeddings/after_2018-2025-05-08_maest.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50c83da3f7f67e48b6f12640e590296521776d9841c9aeff4909c87e10e3dcf2
+size 699307275

--- a/code/essentia-models/maest/embeddings/before_2012-2025-05-08_maest.pkl
+++ b/code/essentia-models/maest/embeddings/before_2012-2025-05-08_maest.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54aaaf8528183b91cc46efc25f1fb78b2087f146d17ce85fae4e5bfb748c984f
+size 699307479

--- a/code/essentia-models/maest/maest.py
+++ b/code/essentia-models/maest/maest.py
@@ -1,0 +1,89 @@
+import os
+import glob
+import pickle
+import argparse
+import datetime
+from essentia.standard import MonoLoader, TensorflowPredictMAEST
+import numpy as np
+
+
+def compute_maest_embeddings_for_folder(folder: str, output_folder: str = None) -> None:
+    """
+    Compute embeddings for every .mp3 in `folder` (including subdirectories) and write to pickle.
+    Output filename is current date (YYYY-MM-DD) with format `<date>_maest.pkl`.
+    Each entry in the pickle contains `id`, `artist`, `song`, and `embedding`.
+    """
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    model_path = "code/essentia-models/maest/discogs-maest-30s-pw-1.pb"
+    if output_folder is None:
+        output_folder = base_dir
+    os.makedirs(output_folder, exist_ok=True)
+
+    # Generate output filename based on current date
+    date_str = datetime.date.today().isoformat()
+    output_filename = f"{date_str}_maest.pkl"
+    output_path = os.path.join(output_folder, output_filename)
+
+    # Initialize the embedding model
+    model = TensorflowPredictMAEST(
+        graphFilename=model_path, output="StatefulPartitionedCall:7"
+    )
+
+    entries = []
+    # Recursively process each MP3 file in sorted order
+    for file_path in sorted(
+        glob.glob(os.path.join(folder, "**", "*.mp3"), recursive=True)
+    ):
+        filename = os.path.basename(file_path)
+        # Split into id, song, and artist based on filename structure <id>-<song>-<artist>
+        name_no_ext = os.path.splitext(filename)[0]
+        parts = name_no_ext.rsplit("-", 2)
+        if len(parts) == 3:
+            id_str, song_str, artist_str = parts
+        elif len(parts) == 2:
+            id_str, song_str = parts
+            artist_str = "unknown"
+        else:
+            id_str = parts[0]
+            song_str = ""
+            artist_str = "unknown"
+
+        # Load audio and compute embedding
+        audio = MonoLoader(filename=file_path, sampleRate=16000, resampleQuality=4)()
+        embedding = model(audio)
+        # Convert embedding to a list of floats
+        try:
+            embedding_list = embedding.tolist()
+        except AttributeError:
+            embedding_list = list(embedding)
+
+        # Reduce embedding dimensionality by averaging and squeezing
+        arr = np.array(embedding_list)
+        embedding_list = np.squeeze(arr.mean(axis=0), axis=0).tolist()
+
+        entries.append(
+            {
+                "id": id_str,
+                "song": song_str,
+                "artist": artist_str,
+                "embedding": embedding_list,
+            }
+        )
+
+    # Write all entries to JSON
+    with open(output_path, "wb") as f:
+        pickle.dump(entries, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    print(f"Processed {len(entries)} files, saved embeddings to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compute MAEST embeddings for all mp3s in a folder"
+    )
+    parser.add_argument("folder", help="Path to folder containing .mp3 files")
+    parser.add_argument(
+        "-o", "--output_folder", help="Directory to save pickle output", default=None
+    )
+    args = parser.parse_args()
+    compute_maest_embeddings_for_folder(args.folder, args.output_folder)


### PR DESCRIPTION
This pull request introduces functionality for generating embeddings from `.mp3` files using the MAEST model and adds the necessary model files. The key changes include the addition of a Python script to compute embeddings, updates to `.gitattributes` for handling large files, and the inclusion of model and output files under Git LFS.

### New functionality for embedding generation:

* [`code/essentia-models/maest/maest.py`](diffhunk://#diff-5ea9fc578a71e79672bcf7cfd568c13c6a720aa8d708a150b46c7f6791783839R1-R89): Added a script to compute embeddings for `.mp3` files in a folder. The script uses the MAEST TensorFlow model and outputs results as a `.pkl` file containing metadata (`id`, `artist`, `song`) and embeddings. It also supports command-line arguments for input and output directories.

### Updates for large file handling:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR4): Added `.pb` files to Git LFS tracking, ensuring efficient handling of large model files.

### Addition of model and output files:

* [`code/essentia-models/maest/discogs-maest-30s-pw-1.pb`](diffhunk://#diff-8934723813e537671555e3dda588ca991a3ee7dbd85a4b3a059f5acf95b6ddd6R1-R3): Added the TensorFlow model file required for embedding generation.
* [`code/essentia-models/maest/embeddings/after_2018-2025-05-08_maest.pkl`](diffhunk://#diff-76585b78cedd79c7c703d138dc1d254c034713de4f99da6c290f8feb2d313c32R1-R3): Added a sample output file containing embeddings generated after a specific date.
* [`code/essentia-models/maest/embeddings/before_2012-2025-05-08_maest.pkl`](diffhunk://#diff-6d049e57494b19b0233cf59176943e4eef3b56138be95c931912b9f55be59944R1-R3): Added another sample output file containing embeddings generated before a specific date.